### PR TITLE
feat: rewrite SCP-style SSH URLs (git@github.com:)

### DIFF
--- a/src/commands/rewrite_urls_with_token.yml
+++ b/src/commands/rewrite_urls_with_token.yml
@@ -1,5 +1,7 @@
 description: >
-  Rewrite all GitHub urls using SSH and HTTPs with an access token provided via environment variable
+  Rewrite all GitHub urls using SSH (both `ssh://git@github.com/` and
+  the SCP-style `git@github.com:` form) and HTTPS with an access token
+  provided via environment variable
 parameters:
   token_env_var:
     default: GITHUB_TOKEN
@@ -11,3 +13,4 @@ steps:
       command: |
         git config set --global --append url."https://token:${<<parameters.token_env_var>>}@github.com/".insteadOf "https://github.com/"
         git config set --global --append url."https://token:${<<parameters.token_env_var>>}@github.com/".insteadOf "ssh://git@github.com/"
+        git config set --global --append url."https://token:${<<parameters.token_env_var>>}@github.com/".insteadOf "git@github.com:"


### PR DESCRIPTION
CircleCI's default `checkout` step sets origin to the SCP-style SSH form (e.g. `git@github.com:org/repo.git`), which is the most common URL format consumers will have. The previous insteadOf rules only covered `https://github.com/` and `ssh://git@github.com/`, so the SCP-style URL fell through and consumers ended up authenticating with the project's deploy key (typically read-only) on push, hitting "The key you are authenticating with has been marked as read only".

Adds a third insteadOf rule for `git@github.com:` to cover this case.
