### PR TITLE
Feature: Upgrade gh-pages to 6.3.0 & add optional publish flags

### DIFF
--- a/src/commands/publish_github_pages.yml
+++ b/src/commands/publish_github_pages.yml
@@ -15,6 +15,18 @@ parameters:
     type: string
     description: Commit message to use for git
     default: "docs: Update github pages [ci skip]"
+  dotfiles:
+    type: boolean
+    description: Include dotfiles when publishing
+    default: false
+  nojekyll:
+    type: boolean
+    description: Add a .nojekyll file to disable Jekyll processing
+    default: false
+  cname:
+    type: string
+    description: Optional custom domain to write into CNAME
+    default: ""
   repository_url:
     type: string
     description: Repository url with env vars
@@ -24,8 +36,19 @@ steps:
       name: Publish GitHub pages
       command: |
         export EMAIL="<<parameters.git_commit_author_email>>"
-        npx gh-pages@2.0.1 \
+        set --
+        if [ "<<parameters.dotfiles>>" = "true" ]; then
+          set -- "$@" "--dotfiles"
+        fi
+        if [ "<<parameters.nojekyll>>" = "true" ]; then
+          set -- "$@" "--nojekyll"
+        fi
+        if [ -n "<<parameters.cname>>" ]; then
+          set -- "$@" "--cname" "<<parameters.cname>>"
+        fi
+        npx gh-pages@6.3.0 \
           -d "<<parameters.folder>>" \
           -u "<<parameters.git_commit_author_name>> <${EMAIL}>" \
           --message "<<parameters.git_commit_messages>>" \
-          --repo "<<parameters.repository_url>>"
+          --repo "<<parameters.repository_url>>" \
+          "$@"

--- a/src/examples/publish_github_pages.yml
+++ b/src/examples/publish_github_pages.yml
@@ -1,0 +1,31 @@
+description: Publish docs folder to GitHub Pages
+usage:
+  version: 2.1
+  orbs:
+    github-utils: trustedshops-public/github-utils@<version>
+  jobs:
+    docs:
+      docker:
+        - image: cimg/node:20.12
+      steps:
+        - checkout
+        - run:
+            name: Build docs
+            command: |
+              mkdir -p docs
+              echo "Documentation generated at $(date)" > docs/index.html
+        - github-utils/publish_github_pages:
+            git_commit_author_name: CircleCI
+            git_commit_author_email: ci@example.com
+            # Optional parameters below can be overridden as needed.
+            # folder: docs/
+            # git_commit_messages: "docs: Update github pages [ci skip]"
+            # dotfiles: false
+            # nojekyll: false
+            # cname: docs.example.com
+            # repository_url: "https://token:${GITHUB_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+  workflows:
+    version: 2
+    continuous:
+      jobs:
+        - docs

--- a/src/examples/publish_github_pages.yml
+++ b/src/examples/publish_github_pages.yml
@@ -6,7 +6,7 @@ usage:
   jobs:
     docs:
       docker:
-        - image: cimg/node:20.12
+        - image: cimg/node:22
       steps:
         - checkout
         - run:


### PR DESCRIPTION
**Summary**
This PR upgrades the GitHub Pages publishing command in the orb to use `gh-pages@6.3.0`, adds optional deployment controls, and introduces a usage example for publishing docs.

**What changed**
- Upgraded `gh-pages` from `2.0.1` to `6.3.0` in the publish command.
- Added new command parameters:
  - `dotfiles` (boolean, default `false`)
  - `nojekyll` (boolean, default `false`)
  - `cname` (string, default `""`)
- Implemented conditional flag passing so optional flags are only set when configured.
- Added a new publish example and documented optional overrides in the example.

**Compatibility / risk**
- Existing flags (`dist`, `user`, `message`, `repo`) remain compatible in `gh-pages@6.3.0`.
- `cname` handling is safe when omitted (`""` does not add `--cname`).
- Runtime note: `gh-pages@6.3.0` requires Node `>=10` (older versions may fail).

**Validation**
- Verified CLI option availability for `dotfiles`, `nojekyll`, and `cname` against upstream `gh-pages` `v6.3.0`.
- Checked command and example YAML for editor-reported errors (none found).

**Why**
This enables newer `gh-pages` features and improves flexibility for GitHub Pages deployments without changing default behavior for existing users.